### PR TITLE
nvim-regexplainer tries to use treesitter on temporary buffers, often causing errors

### DIFF
--- a/lua/regexplainer.lua
+++ b/lua/regexplainer.lua
@@ -77,7 +77,7 @@ local local_config = vim.tbl_deep_extend('keep', default_config, {})
 --
 local function show(options)
   options = vim.tbl_deep_extend('force', local_config, options or {})
-  local node, error = tree.get_regexp_pattern_at_cursor()
+  local node, error = tree.get_regexp_pattern_at_cursor(options.filetypes)
 
   if error and options.debug then
     utils.notify('Rexexplainer: ' .. error, 'debug')

--- a/lua/regexplainer/utils/treesitter.lua
+++ b/lua/regexplainer/utils/treesitter.lua
@@ -233,8 +233,15 @@ end
 --- document root to determine if we're on a regexp
 ---@return any, string|nil
 --
-function M.get_regexp_pattern_at_cursor()
-  local root_lang_tree = vim.treesitter.get_parser(0, vim.treesitter.language.get_lang(vim.bo[0].ft))
+function M.get_regexp_pattern_at_cursor(filetypes)
+  local filetype = vim.bo[0].ft
+
+  -- if filetype is not in the list of filetypes, return early
+  if not vim.tbl_contains(filetypes, filetype) then
+    return nil, 'filetype not in options.filetypes'
+  end
+
+  local root_lang_tree = vim.treesitter.get_parser(0, vim.treesitter.language.get_lang(filetype))
   local cursor_node = get_node_at_cursor(root_lang_tree)
   local cursor_node_type = cursor_node and cursor_node:type()
   if not cursor_node or cursor_node_type == 'program' then


### PR DESCRIPTION
In temporary buffers (such as `Copilot` and `Trouble`), `regexplainer` attempts to use `treesitter` to get the language which leads to an error because `treesitter` can't find parsers for the temporary buffers. I fixed this by returning early in the `get_regexp_pattern_at_cursor` if the file type detected wasn't part of the file types in the user config. I had to send over the file type information to this function though, so it's a really really messy fix. If you could improve it that would be great.