### PR TITLE
feat!: neovim 0.12 readiness

### DIFF
--- a/lua/regexplainer/buffers/popup.lua
+++ b/lua/regexplainer/buffers/popup.lua
@@ -76,7 +76,7 @@ local function create_pattern_popup(pattern_text, image_buffer, options, image_h
   vim.api.nvim_buf_set_lines(pattern_bufnr, 0, -1, false, { formatted_pattern })
 
   -- Set filetype to javascript for syntax highlighting
-  vim.api.nvim_buf_set_option(pattern_bufnr, 'filetype', 'javascript')
+  vim.bo[pattern_bufnr].filetype = 'javascript'
 
   -- Get the NUI popup's actual screen position using window config
   local pattern_width = #formatted_pattern

--- a/lua/regexplainer/buffers/split.lua
+++ b/lua/regexplainer/buffers/split.lua
@@ -78,11 +78,11 @@ local function after(self, lines, options, state)
         local original_win = vim.api.nvim_get_current_win()
         
         -- Temporarily make buffer modifiable to set content
-        vim.api.nvim_buf_set_option(self.bufnr, 'modifiable', true)
-        vim.api.nvim_buf_set_option(self.bufnr, 'readonly', false)
+        vim.bo[self.bufnr].modifiable = true
+        vim.bo[self.bufnr].readonly = false
         vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, {''})
-        vim.api.nvim_buf_set_option(self.bufnr, 'readonly', true)
-        vim.api.nvim_buf_set_option(self.bufnr, 'modifiable', false)
+        vim.bo[self.bufnr].readonly = true
+        vim.bo[self.bufnr].modifiable = false
         
         -- Only switch to split window if it's still valid
         if vim.api.nvim_win_is_valid(split_win) then

--- a/lua/regexplainer/graphics/hologram.lua
+++ b/lua/regexplainer/graphics/hologram.lua
@@ -51,7 +51,7 @@ local function display_image(base64_data, options)
   file:close()
 
   -- Verify the file was created and has content
-  local file_info = vim.loop.fs_stat(temp_file)
+  local file_info = vim.uv.fs_stat(temp_file)
   if not file_info then
     return false
   end

--- a/lua/regexplainer/health.lua
+++ b/lua/regexplainer/health.lua
@@ -1,12 +1,6 @@
 local M = {}
 
-local health = {
-  start = vim.health.start or vim.health.report_start,
-  ok = vim.health.ok or vim.health.report_ok,
-  warn = vim.health.warn or vim.health.report_warn,
-  error = vim.health.error or vim.health.report_error,
-  info = vim.health.info or vim.health.report_info,
-}
+local health = vim.health
 
 --- Check regexplainer health
 function M.check()
@@ -105,7 +99,7 @@ function M.check()
     -- Create a minimal test environment
     local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'test /hello/ world' })
-    vim.api.nvim_buf_set_option(bufnr, 'filetype', 'javascript')
+    vim.bo[bufnr].filetype = 'javascript'
     
     -- Test component creation
     local tree = require 'regexplainer.utils.treesitter'

--- a/lua/regexplainer/renderers/graphical/init.lua
+++ b/lua/regexplainer/renderers/graphical/init.lua
@@ -56,7 +56,7 @@ local function generate_railroad_diagram(components, options, pattern_text)
   local script_path = get_script_path()
 
   -- Convert components to JSON
-  local components_json = vim.fn.json_encode(components)
+  local components_json = vim.json.encode(components)
 
   -- Escape the JSON for shell command
   local escaped_json = vim.fn.shellescape(components_json)
@@ -95,7 +95,7 @@ local function generate_railroad_diagram(components, options, pattern_text)
   end
 
   -- Parse JSON response to get base64 data and actual dimensions
-  local ok, parsed = pcall(vim.fn.json_decode, result)
+  local ok, parsed = pcall(vim.json.decode, result)
   if not ok or not parsed or not parsed.base64 then
     if options.debug then
       utils.notify('Failed to parse Python script JSON response', 'error')

--- a/tests/regexplainer/graphical_spec.lua
+++ b/tests/regexplainer/graphical_spec.lua
@@ -53,7 +53,7 @@ describe('graphical renderer', function()
       -- Create a buffer with a simple regex
       local bufnr = vim.api.nvim_create_buf(false, true)
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'const regex = /test/' })
-      vim.api.nvim_buf_set_option(bufnr, 'filetype', 'javascript')
+      vim.bo[bufnr].filetype = 'javascript'
       vim.api.nvim_set_current_buf(bufnr)
 
       -- Position cursor on the regex

--- a/tests/setup.lua
+++ b/tests/setup.lua
@@ -34,7 +34,7 @@ end
 function Setup.load(plugin)
   local name = plugin:match '.*/(.*)'
   local package_root = Setup.root '.tests/site/pack/deps/start/'
-  if not vim.loop.fs_stat(package_root .. name) then
+  if not vim.uv.fs_stat(package_root .. name) then
     print('Installing ' .. plugin)
     vim.fn.mkdir(package_root, 'p')
     vim.fn.system {


### PR DESCRIPTION
## Summary
- Replace `vim.loop` with `vim.uv`
- Replace `nvim_buf_set_option` with `vim.bo[]`
- Replace `vim.fn.json_encode/decode` with `vim.json.encode/decode`
- Remove `vim.health.report_*` compat shim (available since 0.10)

## Breaking Changes
Minimum supported neovim version is now 0.11.